### PR TITLE
WalletConnect account type

### DIFF
--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -350,7 +350,8 @@
     "multisig_account": "Multipodpisový účet",
     "public_account": "Verejný účet",
     "rekeyed": "Rekeyed account",
-    "ledger_account": "HW ledger účet"
+    "ledger_account": "HW ledger účet",
+    "wc_account": "WalletConnect account"
   },
   "pay": {
     "title": "Nová platba - od",
@@ -597,5 +598,14 @@
     "name": "Name",
     "genesis": "Genesis ID",
     "genesis_hash": "Genesis Hash"
+  },
+  "new_account_wc": {
+    "title": "Add WalletConnect account",
+    "account_name": "Account name",
+    "last_error": "Last error",
+    "scan": "Scan the QR code",
+    "address": "Address",
+    "save_address": "Save the address to the wallet",
+    "copy": "Copy URI to clipboard"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -524,15 +524,6 @@
     "account_name": "Account name",
     "save_address": "Save the address to the wallet"
   },
-  "new_account_wc": {
-    "title": "Add WalletConnect account",
-    "account_name": "Account name",
-    "last_error": "Last error",
-    "scan": "Scan the QR code",
-    "address": "Address",
-    "save_address": "Save the address to the wallet",
-    "copy": "Copy URI to clipboard"
-  },
   "faq": {
     "title": "Frequently asked questions",
     "q1": "About AWallet",
@@ -608,5 +599,14 @@
     "name": "Name",
     "genesis": "Genesis ID",
     "genesis_hash": "Genesis Hash"
+  },
+  "new_account_wc": {
+    "title": "Add WalletConnect account",
+    "account_name": "Account name",
+    "last_error": "Last error",
+    "scan": "Scan the QR code",
+    "address": "Address",
+    "save_address": "Save the address to the wallet",
+    "copy": "Copy URI to clipboard"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -350,7 +350,8 @@
     "multisig_account": "Multisignature account",
     "public_account": "Public account",
     "rekeyed": "Rekeyed account",
-    "ledger_account": "HW ledger account"
+    "ledger_account": "HW ledger account",
+    "wc_account": "WalletConnect account"
   },
   "pay": {
     "title": "Make payment - from",
@@ -522,6 +523,15 @@
     "primary_address": "Primary address",
     "account_name": "Account name",
     "save_address": "Save the address to the wallet"
+  },
+  "new_account_wc": {
+    "title": "Add WalletConnect account",
+    "account_name": "Account name",
+    "last_error": "Last error",
+    "scan": "Scan the QR code",
+    "address": "Address",
+    "save_address": "Save the address to the wallet",
+    "copy": "Copy URI to clipboard"
   },
   "faq": {
     "title": "Frequently asked questions",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -350,7 +350,8 @@
     "multisig_account": "Többszörösen aláírt számla",
     "public_account": "Nyilvános számla",
     "rekeyed": "Rekeyed account",
-    "ledger_account": "HW ledger account"
+    "ledger_account": "HW ledger account",
+    "wc_account": "WalletConnect account"
   },
   "pay": {
     "title": "Kifizetés indítása innen: ",
@@ -597,5 +598,14 @@
     "name": "Name",
     "genesis": "Genesis ID",
     "genesis_hash": "Genesis Hash"
+  },
+  "new_account_wc": {
+    "title": "Add WalletConnect account",
+    "account_name": "Account name",
+    "last_error": "Last error",
+    "scan": "Scan the QR code",
+    "address": "Address",
+    "save_address": "Save the address to the wallet",
+    "copy": "Copy URI to clipboard"
   }
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -350,7 +350,8 @@
     "multisig_account": "Account multifirma",
     "public_account": "Account pubblico",
     "rekeyed": "Rekeyed account",
-    "ledger_account": "HW ledger account"
+    "ledger_account": "HW ledger account",
+    "wc_account": "WalletConnect account"
   },
   "pay": {
     "title": "Effettua pagamento - da",
@@ -597,5 +598,14 @@
     "name": "Name",
     "genesis": "Genesis ID",
     "genesis_hash": "Genesis Hash"
+  },
+  "new_account_wc": {
+    "title": "Add WalletConnect account",
+    "account_name": "Account name",
+    "last_error": "Last error",
+    "scan": "Scan the QR code",
+    "address": "Address",
+    "save_address": "Save the address to the wallet",
+    "copy": "Copy URI to clipboard"
   }
 }

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -350,7 +350,8 @@
     "multisig_account": "Multisignature accout",
     "public_account": "Publiek account",
     "rekeyed": "Rekeyed account",
-    "ledger_account": "HW ledger account"
+    "ledger_account": "HW ledger account",
+    "wc_account": "WalletConnect account"
   },
   "pay": {
     "title": "Maak een betaling - van",
@@ -597,5 +598,14 @@
     "name": "Name",
     "genesis": "Genesis ID",
     "genesis_hash": "Genesis Hash"
+  },
+  "new_account_wc": {
+    "title": "Add WalletConnect account",
+    "account_name": "Account name",
+    "last_error": "Last error",
+    "scan": "Scan the QR code",
+    "address": "Address",
+    "save_address": "Save the address to the wallet",
+    "copy": "Copy URI to clipboard"
   }
 }

--- a/src/locales/sk.json
+++ b/src/locales/sk.json
@@ -350,7 +350,8 @@
     "multisig_account": "Multipodpisový účet",
     "public_account": "Verejný účet",
     "rekeyed": "Rekeyed account",
-    "ledger_account": "HW ledger účet"
+    "ledger_account": "HW ledger účet",
+    "wc_account": "WalletConnect account"
   },
   "pay": {
     "title": "Nová platba - od",
@@ -597,5 +598,14 @@
     "name": "Názov",
     "genesis": "Genesis ID",
     "genesis_hash": "Genesis Hash"
+  },
+  "new_account_wc": {
+    "title": "Add WalletConnect account",
+    "account_name": "Account name",
+    "last_error": "Last error",
+    "scan": "Scan the QR code",
+    "address": "Address",
+    "save_address": "Save the address to the wallet",
+    "copy": "Copy URI to clipboard"
   }
 }

--- a/src/pages/AccountOverview.vue
+++ b/src/pages/AccountOverview.vue
@@ -125,6 +125,12 @@
           >
             {{ $t("acc_type.ledger_account") }}
           </div>
+          <div
+            v-else-if="account.type == 'wc'"
+            class="badge bg-success text-light"
+          >
+            {{ $t("acc_type.wc_account") }}
+          </div>
           <div v-else class="badge bg-info text-dark">
             {{ $t("acc_type.public_account") }}
           </div>

--- a/src/pages/Accounts.vue
+++ b/src/pages/Accounts.vue
@@ -55,6 +55,12 @@
           >
             {{ $t("acc_type.ledger_account") }}
           </div>
+          <div
+            v-else-if="slotProps.data.type == 'wc'"
+            class="badge bg-success text-light"
+          >
+            {{ $t("acc_type.wc_account") }}
+          </div>
           <div v-else class="badge bg-info text-dark">
             {{ $t("acc_type.public_account") }}
           </div>

--- a/src/pages/NewAccount.vue
+++ b/src/pages/NewAccount.vue
@@ -7,6 +7,10 @@
           HW Wallet - Ledger
         </router-link>
 
+        <router-link to="/new-account/wc" class="btn btn-primary m-1">
+          Wallet Connect
+        </router-link>
+
         <button v-if="!w" class="btn btn-primary m-1" @click="createAccount">
           {{ $t("newacc.create_basic") }}</button
         ><button v-if="!w" class="btn btn-primary m-1" @click="createVanity">
@@ -39,12 +43,12 @@
           <div :class="scanMnemonic ? 'col-8' : 'col-12'">
             <p>{{ $t("newacc.write_mnemonic") }}</p>
             <Password
-              inputClass="form-control my-1 w-100"
-              style="width: 100%"
-              inputStyle="width:100%"
-              :feedback="false"
-              :toggleMask="true"
               v-model="w"
+              input-class="form-control my-1 w-100"
+              style="width: 100%"
+              input-style="width:100%"
+              :feedback="false"
+              :toggle-mask="true"
             />
 
             <p>{{ $t("newacc.name") }}</p>
@@ -98,7 +102,9 @@
             vanityRPS
           }}/s)
         </div>
-        <div class="alert alert-success my-2" v-if="a">{{ a }}</div>
+        <div v-if="a" class="alert alert-success my-2">
+          {{ a }}
+        </div>
         <button
           v-if="!vanityRunning"
           class="btn my-1"
@@ -147,10 +153,10 @@
         </p>
         <p>{{ $t("newacc.select_account_from_list") }}:</p>
         <select
+          v-model="multisigaccts"
           class="select form-control"
           multiple
           rows="20"
-          v-model="multisigaccts"
           style="min-height: 150px"
         >
           <option
@@ -163,8 +169,8 @@
         </select>
         <p class="my-2">{{ $t("newacc.add_other_accounts") }}:</p>
         <textarea
-          class="form-control my-1"
           v-model="friendaccounts"
+          class="form-control my-1"
           style="min-height: 150px"
         />
 
@@ -174,21 +180,21 @@
           }}):
         </p>
         <input
+          id="customRange2"
+          v-model="multisignum"
           type="range"
           class="form-range"
           min="1"
           :max="countAccounts()"
-          v-model="multisignum"
-          id="customRange2"
         />
 
         <input
+          id="customRange2"
+          v-model="multisignum"
           type="number"
           class="form-control"
           min="1"
           :max="countAccounts()"
-          v-model="multisignum"
-          id="customRange2"
         />
 
         <p>{{ $t("newacc.name") }}</p>
@@ -201,51 +207,47 @@
           {{ $t("global.go_back") }}
         </button>
       </div>
-      <div v-if="!this.s && page == 'newaccount'">
+      <div v-if="!s && page == 'newaccount'">
         <p>
           {{ $t("newacc.create_account_help") }}
         </p>
-        <button v-if="!this.s" class="btn btn-primary" @click="this.s = true">
+        <button v-if="!s" class="btn btn-primary" @click="s = true">
           {{ $t("newacc.show_mnemonic") }}
         </button>
       </div>
-      <div v-if="this.s && this.challenge">
+      <div v-if="s && challenge">
         <p>{{ $t("newacc.position_question") }} {{ r }}?</p>
-        <input class="form-control" v-model="guess" />
+        <input v-model="guess" class="form-control" />
         <p>{{ $t("newacc.name") }}</p>
         <input v-model="name" class="form-control" />
-        <button
-          v-if="this.s"
-          class="btn btn-primary m-1"
-          @click="confirmCreate"
-        >
+        <button v-if="s" class="btn btn-primary m-1" @click="confirmCreate">
           {{ $t("newacc.create_account") }}
         </button>
         <button
-          v-if="this.s"
+          v-if="s"
           class="btn btn-primary m-1"
           @click="
-            this.challenge = false;
-            this.s = false;
+            challenge = false;
+            s = false;
           "
         >
           {{ $t("global.go_back") }}
         </button>
       </div>
-      <div v-if="this.s && !this.challenge && page == 'newaccount'">
+      <div v-if="s && !challenge && page == 'newaccount'">
         <p>
           {{ $t("newacc.mnemonic_help") }}
         </p>
 
-        <textarea class="form-control my-1" v-model="w" />
-        <input class="form-control my-1" v-model="a" />
+        <textarea v-model="w" class="form-control my-1" />
+        <input v-model="a" class="form-control my-1" />
 
         <QRCodeVue3
           :width="500"
           :height="500"
           :value="w"
-          :cornersSquareOptions="{ type: 'square', color: '#333' }"
-          :cornersDotOptions="{
+          :corners-square-options="{ type: 'square', color: '#333' }"
+          :corners-dot-options="{
             type: 'square',
             color: '#333',
             gradient: {
@@ -257,7 +259,7 @@
               ],
             },
           }"
-          :dotsOptions="{
+          :dots-options="{
             type: 'square',
             color: '#333',
             gradient: {
@@ -271,16 +273,16 @@
           }"
         />
 
-        <button v-if="this.s" class="btn btn-primary m-1" @click="makeRandom">
+        <button v-if="s" class="btn btn-primary m-1" @click="makeRandom">
           {{ $t("newacc.start_challenge") }}
         </button>
-        <button v-if="this.s" class="btn btn-light m-1" @click="createAccount">
+        <button v-if="s" class="btn btn-light m-1" @click="createAccount">
           {{ $t("newacc.create_new") }}
         </button>
-        <button v-if="this.s" class="btn btn-light m-1" @click="this.s = false">
+        <button v-if="s" class="btn btn-light m-1" @click="s = false">
           {{ $t("newacc.hide_mnemonic") }}
         </button>
-        <button v-if="this.s" class="btn btn-light m-1" @click="reset">
+        <button v-if="s" class="btn btn-light m-1" @click="reset">
           {{ $t("newacc.drop_phrase") }}
         </button>
       </div>
@@ -298,6 +300,11 @@ import moment from "moment";
 import Worker from "worker-loader!../workers/vanity";
 
 export default {
+  components: {
+    MainLayout,
+    QRCodeVue3,
+    QrcodeStream,
+  },
   data() {
     return {
       r: 0,
@@ -324,11 +331,6 @@ export default {
       vanityTime: "",
       vanityRPS: "", // results per second
     };
-  },
-  components: {
-    MainLayout,
-    QRCodeVue3,
-    QrcodeStream,
   },
   mounted() {
     this.reset();

--- a/src/pages/NewAccount/WalletConnect.vue
+++ b/src/pages/NewAccount/WalletConnect.vue
@@ -1,0 +1,114 @@
+<template>
+  <MainLayout>
+    <h1>{{ $t("new_account_wc.title") }}</h1>
+    <div v-if="lastError">
+      <div class="alert alert-danger">
+        {{ $t("new_account_wc.last_error") }}: {{ lastError }}
+      </div>
+    </div>
+    <h3>{{ $t("new_account_wc.account_name") }}</h3>
+    <input v-model="name" class="form-control my-2" />
+
+    <div v-if="scannable">
+      <h3>{{ $t("new_account_wc.scan") }}</h3>
+      <QRCodeVue3
+        :width="400"
+        :height="400"
+        :value="uri"
+        :qr-options="{ errorCorrectionLevel: 'H' }"
+      />
+      <button class="btn btn-primary m-1" @click="clickCopy">
+        {{ $t("new_account_wc.copy") }}
+      </button>
+    </div>
+    <div v-if="params">
+      <div v-if="params.accounts[0]">
+        {{ $t("new_account_wc.address") }}: {{ params.accounts[0] }}
+      </div>
+      <button class="btn btn-primary my-2" @click="clickSave">
+        {{ $t("new_account_wc.save_address") }}
+      </button>
+    </div>
+  </MainLayout>
+</template>
+
+<script>
+import MainLayout from "../../layouts/Main.vue";
+import QRCodeVue3 from "qrcode-vue3";
+import WalletConnect from "@walletconnect/client";
+import copy from "copy-to-clipboard";
+
+import { mapActions } from "vuex";
+export default {
+  components: {
+    MainLayout,
+    QRCodeVue3,
+  },
+  data() {
+    return {
+      lastError: "",
+      name: "",
+      uri: "",
+      params: null,
+      connector: null,
+    };
+  },
+  computed: {
+    scannable() {
+      return this.uri && !this.params;
+    },
+  },
+  mounted() {
+    this.lastError = "";
+    this.prolong();
+
+    this.connector = new WalletConnect({
+      bridge: "https://bridge.walletconnect.org",
+      session: {},
+    });
+
+    this.connector.createSession().then(() => {
+      this.uri = this.connector.uri;
+    });
+
+    // Subscribe to connection events
+    this.connector.on("connect", (error, payload) => {
+      if (error) {
+        throw error;
+      }
+
+      this.params = payload.params[0];
+    });
+  },
+  methods: {
+    ...mapActions({
+      prolong: "wallet/prolong",
+      openError: "toast/openError",
+      addWalletConnectAccount: "wallet/addWalletConnectAccount",
+    }),
+    async clickCopy() {
+      if (copy(this.uri)) {
+        alert(this.$t("global.copied_to_clipboard"));
+      }
+    },
+    async clickSave() {
+      if (this.connector) {
+        this.connector.off("connect");
+      }
+
+      try {
+        this.lastError = "";
+        await this.addWalletConnectAccount({
+          name: this.name,
+          addr: this.params.accounts[0],
+          session: this.connector.session,
+        });
+        this.$router.push({ name: "Accounts" });
+      } catch (Error) {
+        console.error(Error.message);
+        this.lastError = Error;
+      }
+    },
+  },
+};
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -32,6 +32,7 @@ import Success from "@/pages/Success.vue";
 import Swap from "@/pages/Swap.vue";
 import Arc14 from "@/pages/Arc14.vue";
 import NewAccountLedger from "@/pages/NewAccount/Ledger.vue";
+import NewAccountWalletConnect from "@/pages/NewAccount/WalletConnect.vue";
 
 const routes = [
   {
@@ -48,6 +49,11 @@ const routes = [
     path: "/new-account/ledger",
     name: "NewAccountLedger",
     component: NewAccountLedger,
+  },
+  {
+    path: "/new-account/wc",
+    name: "NewAccountWalletConnect",
+    component: NewAccountWalletConnect,
   },
   {
     path: "/swap/:account",

--- a/src/store/signer.js
+++ b/src/store/signer.js
@@ -1,6 +1,7 @@
 import algosdk from "algosdk";
 import Algorand from "@ledgerhq/hw-app-algorand";
 import TransportWebUSB from "@ledgerhq/hw-transport-webusb";
+import WalletConnect from "@walletconnect/client";
 
 const state = () => ({
   signed: {},
@@ -52,6 +53,11 @@ const actions = {
       if (fromAccount.type == "ledger") {
         // sign with ledger
         return await dispatch("signByLedger", {
+          from: fromAccount.addr,
+          tx: txObj,
+        });
+      } else if (fromAccount.type == "wc") {
+        return await dispatch("signByWC", {
           from: fromAccount.addr,
           tx: txObj,
         });
@@ -145,6 +151,46 @@ const actions = {
       throw e;
     }
   },
+  async signByWC({ dispatch, commit }, { from, tx }) {
+    try {
+      console.log("signByWC", { from, tx });
+
+      const fromAccount = this.state.wallet.privateAccounts.find(
+        (a) => a.addr == from
+      );
+      const connector = new WalletConnect({
+        session: fromAccount.session,
+        sessionStorage: {
+          getSession: () => {
+            return null;
+          },
+        },
+      });
+
+      const request = {
+        method: "algo_signTxn",
+        params: [
+          [
+            {
+              txn: Buffer.from(algosdk.encodeUnsignedTransaction(tx)).toString(
+                "base64"
+              ),
+              authAddr: from,
+            },
+          ],
+        ],
+      };
+
+      const response = await connector.sendCustomRequest(request);
+
+      const ret = Buffer.from(response[0], "base64");
+      commit("setSigned", ret);
+      return ret;
+    } catch (e) {
+      console.error("signByWC.e", e);
+      throw e;
+    }
+  },
   async signBySk({ dispatch, commit }, { from, tx }) {
     const sk = await dispatch(
       "wallet/getSK",
@@ -233,6 +279,8 @@ const actions = {
     if (signatorAccount.type == "ledger") {
       // sign by ledger
       return await dispatch("signMultisigByLedger", { msigTx, signator });
+    } else if (signatorAccount.type == "wc") {
+      return await dispatch("signMultisigByWC", { msigTx, signator });
     } else if (signatorAccount.sk) {
       // sk account
       return await dispatch("signMultisigBySk", { msigTx, signator, txn });
@@ -305,6 +353,33 @@ const actions = {
       tx: txn,
     });
     console.log("signMultisigByLedger.sigInnerTx", sigInnerTx);
+    const sigInnerTxObj = algosdk.decodeSignedTransaction(sigInnerTx);
+    console.log("sigInnerTxObj", sigInnerTxObj);
+    let keyExist = false;
+    signedTxn.msig.subsig.forEach((subsig, i) => {
+      const subsigAddr = algosdk.encodeAddress(subsig.pk);
+      if (subsigAddr == signator) {
+        keyExist = true;
+        signedTxn.msig.subsig[i].s = sigInnerTxObj.sig;
+      }
+    });
+    if (!keyExist) {
+      throw new Error(`Multisig key is missing for address ${signator}`);
+    }
+    const ret = algosdk.encodeObj(signedTxn);
+    commit("setSigned", ret);
+    return ret;
+  },
+  async signMultisigByWC({ dispatch, commit }, { msigTx, signator }) {
+    const signedTxn = algosdk.decodeObj(msigTx);
+    const txn = algosdk.decodeUnsignedTransaction(
+      algosdk.encodeObj(signedTxn.txn)
+    );
+    const sigInnerTx = await dispatch("signByWC", {
+      from: signator,
+      tx: txn,
+    });
+    console.log("signMultisigByWC.sigInnerTx", sigInnerTx);
     const sigInnerTxObj = algosdk.decodeSignedTransaction(sigInnerTx);
     console.log("sigInnerTxObj", sigInnerTxObj);
     let keyExist = false;

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -69,6 +69,10 @@ const mutations = {
     const account = { name, addr, addr0, slot, type: "ledger" };
     state.privateAccounts.push(account);
   },
+  addWalletConnectAccount(state, { name, addr, session }) {
+    const account = { name, addr, session, type: "wc" };
+    state.privateAccounts.push(account);
+  },
   setPrivateAccounts(state, accts) {
     if (accts) {
       state.privateAccounts = accts;
@@ -216,6 +220,20 @@ const actions = {
     }
     try {
       await commit("addLedgerAccount", { name, addr, addr0, slot });
+      await dispatch("saveWallet");
+      return true;
+    } catch (e) {
+      console.error("error", e);
+      alert("Account has not been created");
+    }
+  },
+  async addWalletConnectAccount({ dispatch, commit }, { name, addr, session }) {
+    if (!name) {
+      alert("Plase set account name");
+      return false;
+    }
+    try {
+      await commit("addWalletConnectAccount", { name, addr, session });
       await dispatch("saveWallet");
       return true;
     } catch (e) {


### PR DESCRIPTION
Adds a new account type (WalletConnect account) that allows connecting any WalletConnect compatible wallet to AWallet and then use it either as a regular account or a multisig participant.

Verified to work with Pera, Defly and a custom, command-line wallet (https://github.com/dragmz/ams).