### PR TITLE
Change button text while importing an account for better clarity

### DIFF
--- a/src/pages/NewAccount.vue
+++ b/src/pages/NewAccount.vue
@@ -51,7 +51,7 @@
             <input v-model="name" class="form-control" />
 
             <button class="btn btn-primary m-1" @click="importAccountClick">
-              {{ $t("newacc.create_account") }}
+              {{ $t("newacc.import_account") }}
             </button>
 
             <button


### PR DESCRIPTION
Hi there. For better clarity, while on the "importaccount" page, the button to add the account can be updated to "Import account" instead of "Create account", since it does not involve the user to view the mneomic phrase or perform the challenge. 