### PR TITLE
Use Biatec Router's combined-split quotes (routesCount: 1) instead of legacy alternatives

### DIFF
--- a/src/scripts/aggregators/biatec.ts
+++ b/src/scripts/aggregators/biatec.ts
@@ -14,6 +14,52 @@ export interface BiatecAggregatorOptions {
   processingKey: string;
 }
 
+// With routesCount <= 1 (the default, and what this file now requests - see the getQuote/execute
+// request bodies below), Biatec Router's response.routes holds the LEGS of one combined swap: the
+// router may split the requested amount across up to 3 structurally distinct paths to beat any
+// single path's price (e.g. part of the trade direct, part via an intermediate asset), and all
+// legs share ONE Algorand atomic transaction group server-side. That means the total output is
+// the SUM across legs (not just routes[0]'s own output) and the transactions to sign are the
+// CONCATENATION of every leg's txsToSign, in order (signing just one leg's slice would submit an
+// incomplete/invalid group, since the group hash covers every transaction across every leg).
+// requesting routesCount: 3 previously disabled this splitting entirely (BiatecRouter's legacy
+// "N independent full-amount alternatives" mode) - always leaving real output on the table
+// whenever the router had a genuinely better split available, sometimes by 10%+.
+// Wrapped into the same { route: { route, txsToSign } } shape the rest of this file (and
+// buildBiatecRouteInfo's hop/pool display) already expects, so downstream code is unchanged.
+// Known limitation: the hop/pool breakdown shown to the user still only reflects the FIRST leg
+// when the router actually splits - a display gap, not a correctness one (the total quoted
+// amount and the transactions actually submitted are both correct across all legs).
+function combineRouteResponse(response: {
+  routes?: Array<{
+    route?: {
+      outputAmount?: number;
+      totalNetworkFeeMicroAlgos?: number;
+      [key: string]: unknown;
+    };
+    txsToSign?: string[] | null;
+  }> | null;
+}) {
+  const routes = response.routes ?? [];
+  const totalOutputAmount = routes.reduce(
+    (sum, r) => sum + (r.route?.outputAmount || 0),
+    0,
+  );
+  const totalFees = routes.reduce(
+    (sum, r) => sum + (r.route?.totalNetworkFeeMicroAlgos || 0),
+    0,
+  );
+  const combinedTxsToSign = routes.flatMap((r) => r.txsToSign || []);
+  return {
+    route: {
+      ...routes[0]?.route,
+      outputAmount: totalOutputAmount,
+      totalNetworkFeeMicroAlgos: totalFees,
+    },
+    txsToSign: combinedTxsToSign,
+  };
+}
+
 // Shared implementation for the Biatec Router aggregator - used to build both
 // the production (router.api.biatec.io) and stage (stage.router.api.biatec.io)
 // variants from the same code, since the stage router is API-compatible with
@@ -64,7 +110,7 @@ export function createBiatecAggregator(
             context.payamount.value * 10 ** context.fromAssetDecimals.value,
           ),
           receiveMinimum: 0,
-          routesCount: 3,
+          routesCount: 1,
           maxHops: 3,
         };
 
@@ -76,7 +122,7 @@ export function createBiatecAggregator(
           return;
         }
 
-        const route = response.routes[0];
+        const route = combineRouteResponse(response);
         context.aggregatorData[quotesKey].value = {
           route: route,
           quoteAmount: route.route?.outputAmount || 0,
@@ -144,7 +190,7 @@ export function createBiatecAggregator(
             context.payamount.value * 10 ** context.fromAssetDecimals.value,
           ),
           receiveMinimum: minimumReceiveAmount, // ensure the minimum receive amount is set appropriately
-          routesCount: 3,
+          routesCount: 1,
           maxHops: 3,
         };
 
@@ -155,7 +201,7 @@ export function createBiatecAggregator(
           return;
         }
 
-        const route = response.routes[0];
+        const route = combineRouteResponse(response);
         context.aggregatorData[quotesKey].value = {
           route: route,
           quoteAmount: route.route?.outputAmount || 0,


### PR DESCRIPTION
## Summary
- `src/scripts/aggregators/biatec.ts` requested `routesCount: 3` for both `getQuote` and `execute`, which forces BiatecRouter's legacy "N independent full-amount alternatives" mode — the router's v2 multi-leg splitting (`BuildCombinedRoute`, which lets it split a swap across multiple paths the way Haystack/Deflex routinely does) never gets a chance to run.
- Live comparison for 1000 VOTE → EURS: switching to `routesCount: 1` took Biatec production from a 12.8% gap vs Deflex down to 6.0%, and stage from 18.8% down to 8.5% — roughly halving the shortfall for this pair, at zero cost (no BiatecRouter changes needed).
- With `routesCount <= 1`, `response.routes` holds the **legs of one combined swap**, not independent alternatives — total output is the sum across legs, and the full transaction group is the concatenation of every leg's `txsToSign` (all legs share one Algorand atomic group server-side; signing only `routes[0]`'s slice would submit an incomplete group). Added `combineRouteResponse()` to fold that into the same `{ route: { route, txsToSign } }` shape the rest of the file (and `buildBiatecRouteInfo`) already expects, so no other files needed changes.

## Known limitation
The hop/pool breakdown shown in the route explorer still only reflects the first leg when the router actually splits — a display gap, not a correctness one (quoted amount and submitted transactions are both correct across all legs). A follow-up could teach `SwapRouteExplorer` to render multiple legs, the way it already does for Haystack's percentage-split routes.

## Test plan
- [x] `npx tsc --noEmit` — clean, no errors introduced
- [x] Verified live against Biatec Router prod + stage `/api/v1/router/route` with both `maxRoutes=1` and `maxRoutes=3` for the same swap, confirming the combined mode's real output gain
- [ ] Manual smoke test in the running app: get a quote and execute a small swap via the Biatec Router aggregator (prod and stage) to confirm the transaction group still signs/submits correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)