### PR TITLE
fix: merge hops across all legs in combined route response

### DIFF
--- a/src/scripts/aggregators/biatec.ts
+++ b/src/scripts/aggregators/biatec.ts
@@ -27,14 +27,14 @@ export interface BiatecAggregatorOptions {
 // whenever the router had a genuinely better split available, sometimes by 10%+.
 // Wrapped into the same { route: { route, txsToSign } } shape the rest of this file (and
 // buildBiatecRouteInfo's hop/pool display) already expects, so downstream code is unchanged.
-// Known limitation: the hop/pool breakdown shown to the user still only reflects the FIRST leg
-// when the router actually splits - a display gap, not a correctness one (the total quoted
-// amount and the transactions actually submitted are both correct across all legs).
+// hops are merged across every leg too (see below), so the displayed breakdown covers the full
+// split, not just the first leg.
 function combineRouteResponse(response: {
   routes?: Array<{
     route?: {
       outputAmount?: number;
       totalNetworkFeeMicroAlgos?: number;
+      hops?: unknown[] | null;
       [key: string]: unknown;
     };
     txsToSign?: string[] | null;
@@ -49,10 +49,15 @@ function combineRouteResponse(response: {
     (sum, r) => sum + (r.route?.totalNetworkFeeMicroAlgos || 0),
     0,
   );
+  // Each leg carries its own hops; spreading only routes[0]?.route would silently drop every
+  // other leg's hops even though outputAmount/txsToSign are (correctly) summed/concatenated
+  // across all legs - merge them so the displayed route accounts for the full split.
+  const combinedHops = routes.flatMap((r) => r.route?.hops || []);
   const combinedTxsToSign = routes.flatMap((r) => r.txsToSign || []);
   return {
     route: {
       ...routes[0]?.route,
+      hops: combinedHops,
       outputAmount: totalOutputAmount,
       totalNetworkFeeMicroAlgos: totalFees,
     },


### PR DESCRIPTION
## Summary
- `combineRouteResponse()` (added in #165) correctly sums `outputAmount`/`totalNetworkFeeMicroAlgos` and concatenates `txsToSign` across every leg of a v2 combined split, but only spread `routes[0]?.route` for everything else - so the displayed `hops` array silently reflected just the first leg.
- A multi-leg swap could show e.g. 16 transactions to sign but only 2 hops, since later legs' hops were dropped even though their transactions were included and their output was counted in the total.
- Fix: merge `hops` across every leg (`routes.flatMap((r) => r.route?.hops || [])`) instead of relying on the spread of `routes[0]`.

Root-caused and verified against BiatecRouter's own snapshot-based test infrastructure (`RouterServiceMultiLegHopsTests`, in the BiatecRouter repo) - the router's API response was already complete per-leg, confirming the gap was purely in this wallet-side display merge. See `docs/incidents/multi-leg-hops-not-fully-displayed.md` in BiatecRouter for the full investigation.

Note: #165 was merged before this follow-up commit was pushed to its branch, so it never landed in `master` - this PR carries that same commit forward.

## Test plan
- [x] `npx tsc --noEmit` passes for the changed file
- [ ] Manual: fetch a GOLD -> USDC (or similar) quote that produces a multi-leg combined split and confirm the displayed hops cover every leg, matching the transaction count

🤖 Generated with [Claude Code](https://claude.com/claude-code)