### PR TITLE
fix: Biatec Router quote input shows only the first leg of a split route

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,29 @@
+name: Unit Tests
+on: [push]
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.10.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "26.x"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        # Node-only unit tests (playwright/unit) never launch a browser, so
+        # neither the Cypress binary nor Playwright browsers are needed here.
+        run: pnpm install --frozen-lockfile
+        env:
+          CYPRESS_INSTALL_BINARY: "0"
+
+      - name: Run unit tests
+        run: pnpm run test:unit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This document tracks the evolution of AWallet, an open-source Algorand wallet, s
 
 ## 2026-08
 
+- Fixed the Biatec Router route summary on the Swap page: when the router splits a swap across several legs, the displayed INPUT amount now shows the total paid across all legs instead of only the first leg's input, so quotes are no longer misread as worse than they are.
 - Added support for ARC-60 arbitrary data signing over WalletConnect: connected DApps can now request an authentication signature over arbitrary data (not just transactions), which the wallet displays with the requesting domain, purpose, and full data preview before signing — and refuses to sign if the request's domain binding doesn't match, to protect against spoofed sign-in requests.
 - Improved DEX aggregator swaps (Deflex, Folks Router, Biatec Router, Biatec Stage Router)
 - Biatec Router swaps are now available on Testnet, not just Mainnet.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,9 @@ Cypress requires its binary, which frequently fails to install in sandboxed/rest
 - Interactive: `pnpm run test:open` (starts server + opens Cypress UI)
 - Specs live under `cypress/e2e/<n-category>/*.cy.ts`, numbered by test phase (e.g. `1-basic-tests`, `2-setup-account`).
 
-There is no unit test runner in this repo — correctness is verified via type-checking, lint, and Cypress E2E flows.
+### Unit tests (Playwright, Node-only)
+
+`pnpm run test:unit` runs pure Node unit tests via Playwright's test runner (`playwright.unit.config.ts`, specs in `playwright/unit/*.spec.ts`) — no browser, no dev server, no video, so they run in under a second and also run in CI (`.github/workflows/unit-tests.yml`). Use this for pure logic under `src/scripts/` (e.g. `combineBiatecRoute.ts`): keep the module under test free of runtime imports (type-only imports are fine — they're erased, so transitive `vue`/`algosdk` imports in `types.ts` never load at runtime) and import it into the spec via a relative path. Everything browser-dependent is still verified via type-checking, lint, and Cypress/Playwright E2E flows.
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build:scripts": "tsc -p tsconfig.scripts.json",
     "generate:biatec-scan-client": "openapi --input https://api.testnet.scan.biatec.io/swagger/v1/swagger.json --output src/scripts/generated/biatecScan --client fetch --name BiatecScanClient --useOptions",
     "test": "pnpm run build:scripts && node scripts/run-tests.js",
+    "test:unit": "playwright test -c playwright.unit.config.ts",
     "test:parallel": "run-p server cypress:run",
     "test:video": "run-p server cypress:run-video",
     "test:prepare": "pnpm run build",

--- a/playwright.unit.config.ts
+++ b/playwright.unit.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+// Config for pure Node unit tests (playwright/unit/*.spec.ts) - tests of
+// browser-free logic imported straight from src/. Unlike playwright.config.ts
+// there is deliberately no webServer, no browser project, no video and no
+// slowMo: these specs never touch a page, so they run in milliseconds.
+export default defineConfig({
+  testDir: "./playwright/unit",
+  fullyParallel: true,
+  retries: 0,
+  reporter: [["list"]],
+  timeout: 30000,
+});

--- a/playwright/unit/combineBiatecRoute.spec.ts
+++ b/playwright/unit/combineBiatecRoute.spec.ts
@@ -1,0 +1,101 @@
+// Node-only unit test (no browser, no dev server) for the pure Biatec Router
+// split-route combination logic. Run via `pnpm run test:unit`
+// (playwright test -c playwright.unit.config.ts).
+import { test, expect } from "@playwright/test";
+import type { biatecRouter } from "biatec-router";
+import { combineRouteResponse } from "../../src/scripts/aggregators/combineBiatecRoute";
+
+// Mirrors the real production scenario that surfaced the bug: a 100 USDC swap
+// the router split 40/40/20 across three legs. The combined route the app
+// displays and compares must account for ALL legs' inputs/outputs/fees/hops,
+// not just the first leg's.
+function makeSplitResponse(): biatecRouter.RouteOutputCover {
+  const leg = (
+    inputAmount: number,
+    outputAmount: number,
+    fee: number,
+    hops: biatecRouter.HopExecution[],
+    txs: string[],
+  ) => ({
+    route: {
+      fromAsset: 31566704, // USDC
+      toAsset: 227855942, // EURS
+      inputAmount,
+      outputAmount,
+      totalNetworkFeeMicroAlgos: fee,
+      hops,
+    },
+    txsToSign: txs,
+  });
+  return {
+    routes: [
+      leg(
+        40_000_000,
+        20_448_600,
+        21_000,
+        [{ fromAsset: 31566704, toAsset: 0, inputAmount: 40_000_000 }],
+        ["txA1", "txA2"],
+      ),
+      leg(
+        40_000_000,
+        17_322_958,
+        21_000,
+        [{ fromAsset: 31566704, toAsset: 312769, inputAmount: 40_000_000 }],
+        ["txB1"],
+      ),
+      leg(
+        20_000_000,
+        6_388_959,
+        21_000,
+        [{ fromAsset: 31566704, toAsset: 386192725, inputAmount: 20_000_000 }],
+        ["txC1", "txC2"],
+      ),
+    ],
+  };
+}
+
+test("sums inputAmount across every leg of a split route, not just the first", () => {
+  const combined = combineRouteResponse(makeSplitResponse());
+  expect(combined.route.inputAmount).toBe(100_000_000);
+});
+
+test("sums outputAmount and network fees across every leg", () => {
+  const combined = combineRouteResponse(makeSplitResponse());
+  expect(combined.route.outputAmount).toBe(20_448_600 + 17_322_958 + 6_388_959);
+  expect(combined.route.totalNetworkFeeMicroAlgos).toBe(63_000);
+});
+
+test("concatenates hops and txsToSign across every leg, in order", () => {
+  const combined = combineRouteResponse(makeSplitResponse());
+  expect(combined.route.hops?.length).toBe(3);
+  expect(combined.txsToSign).toEqual(["txA1", "txA2", "txB1", "txC1", "txC2"]);
+});
+
+test("a single-leg route passes through unchanged", () => {
+  const single: biatecRouter.RouteOutputCover = {
+    routes: [
+      {
+        route: {
+          fromAsset: 0,
+          toAsset: 31566704,
+          inputAmount: 5_000_000,
+          outputAmount: 1_234_567,
+          totalNetworkFeeMicroAlgos: 4_000,
+          hops: [{ fromAsset: 0, toAsset: 31566704, inputAmount: 5_000_000 }],
+        },
+        txsToSign: ["tx1"],
+      },
+    ],
+  };
+  const combined = combineRouteResponse(single);
+  expect(combined.route.inputAmount).toBe(5_000_000);
+  expect(combined.route.outputAmount).toBe(1_234_567);
+  expect(combined.txsToSign).toEqual(["tx1"]);
+});
+
+test("an empty routes array yields a zeroed combined route", () => {
+  const combined = combineRouteResponse({ routes: [] });
+  expect(combined.route.inputAmount).toBe(0);
+  expect(combined.route.outputAmount).toBe(0);
+  expect(combined.txsToSign).toEqual([]);
+});

--- a/src/scripts/aggregators/biatec.ts
+++ b/src/scripts/aggregators/biatec.ts
@@ -1,6 +1,5 @@
 import type {
   AggregatorQuoteData,
-  BiatecCombinedRoute,
   BiatecQuoteData,
   DexAggregator,
   SwapContext,
@@ -13,6 +12,7 @@ import type {
 import { biatecRouter } from "biatec-router";
 import algosdk from "algosdk";
 import { Buffer } from "buffer";
+import { combineRouteResponse } from "./combineBiatecRoute";
 import { getEffectiveQuoteAmount } from "./simulate";
 import { assertSwapTransactionsSafe } from "./validate";
 
@@ -27,52 +27,6 @@ export interface BiatecAggregatorOptions {
   quotesKey: string;
   txnsKey: string;
   processingKey: string;
-}
-
-// With routesCount <= 1 (the default, and what this file now requests - see the getQuote/execute
-// request bodies below), Biatec Router's response.routes holds the LEGS of one combined swap: the
-// router may split the requested amount across up to 3 structurally distinct paths to beat any
-// single path's price (e.g. part of the trade direct, part via an intermediate asset), and all
-// legs share ONE Algorand atomic transaction group server-side. That means the total output is
-// the SUM across legs (not just routes[0]'s own output) and the transactions to sign are the
-// CONCATENATION of every leg's txsToSign, in order (signing just one leg's slice would submit an
-// incomplete/invalid group, since the group hash covers every transaction across every leg).
-// requesting routesCount: 3 previously disabled this splitting entirely (BiatecRouter's legacy
-// "N independent full-amount alternatives" mode) - always leaving real output on the table
-// whenever the router had a genuinely better split available, sometimes by 10%+.
-// Wrapped into the same { route: { route, txsToSign } } shape the rest of this file (and
-// buildBiatecRouteInfo's hop/pool display) already expects, so downstream code is unchanged.
-// hops are merged across every leg too (see below), so the displayed breakdown covers the full
-// split, not just the first leg.
-function combineRouteResponse(
-  response: biatecRouter.RouteOutputCover,
-): BiatecCombinedRoute {
-  const routes = response.routes ?? [];
-  const totalOutputAmount = routes.reduce(
-    (sum, r) => sum + (r.route?.outputAmount || 0),
-    0,
-  );
-  const totalFees = routes.reduce(
-    (sum, r) => sum + (r.route?.totalNetworkFeeMicroAlgos || 0),
-    0,
-  );
-  // Each leg carries its own hops; spreading only routes[0]?.route would silently drop every
-  // other leg's hops even though outputAmount/txsToSign are (correctly) summed/concatenated
-  // across all legs - merge them so the displayed route accounts for the full split.
-  const combinedHops: biatecRouter.HopExecution[] = routes.flatMap(
-    (r) => r.route?.hops || [],
-  );
-  const combinedTxsToSign: string[] = routes.flatMap((r) => r.txsToSign || []);
-  const route: biatecRouter.QuoteRoute = {
-    ...routes[0]?.route,
-    hops: combinedHops,
-    outputAmount: totalOutputAmount,
-    totalNetworkFeeMicroAlgos: totalFees,
-  };
-  return {
-    route,
-    txsToSign: combinedTxsToSign,
-  };
 }
 
 // Shared implementation for the Biatec Router aggregator - used to build both

--- a/src/scripts/aggregators/combineBiatecRoute.ts
+++ b/src/scripts/aggregators/combineBiatecRoute.ts
@@ -1,0 +1,65 @@
+// Pure combination logic for Biatec Router's split-route responses, kept free
+// of runtime imports (types only) so it can be unit-tested directly in Node
+// (see playwright/unit/combineBiatecRoute.spec.ts) without dragging in
+// algosdk/vue/the aggregator context.
+
+// biatecRouter is a namespace object (both value and type namespace) - the
+// generated client's individual response types (QuoteRoute, HopExecution,
+// RouteOutputCover, ...) are only reachable as members of it
+// (biatecRouter.QuoteRoute etc.), not as top-level named exports of the
+// package.
+import type { biatecRouter } from "biatec-router";
+import type { BiatecCombinedRoute } from "./types";
+
+// With routesCount <= 1 (the default, and what biatec.ts requests - see the getQuote/execute
+// request bodies there), Biatec Router's response.routes holds the LEGS of one combined swap: the
+// router may split the requested amount across up to 3 structurally distinct paths to beat any
+// single path's price (e.g. part of the trade direct, part via an intermediate asset), and all
+// legs share ONE Algorand atomic transaction group server-side. That means the total input spent
+// and total output received are each the SUM across legs (not just routes[0]'s own amounts) and
+// the transactions to sign are the CONCATENATION of every leg's txsToSign, in order (signing just
+// one leg's slice would submit an incomplete/invalid group, since the group hash covers every
+// transaction across every leg).
+// requesting routesCount: 3 previously disabled this splitting entirely (BiatecRouter's legacy
+// "N independent full-amount alternatives" mode) - always leaving real output on the table
+// whenever the router had a genuinely better split available, sometimes by 10%+.
+// Wrapped into the same { route: { route, txsToSign } } shape the rest of biatec.ts (and
+// buildBiatecRouteInfo's hop/pool display) already expects, so downstream code is unchanged.
+// hops are merged across every leg too (see below), so the displayed breakdown covers the full
+// split, not just the first leg.
+export function combineRouteResponse(
+  response: biatecRouter.RouteOutputCover,
+): BiatecCombinedRoute {
+  const routes = response.routes ?? [];
+  const totalInputAmount = routes.reduce(
+    (sum, r) => sum + (r.route?.inputAmount || 0),
+    0,
+  );
+  const totalOutputAmount = routes.reduce(
+    (sum, r) => sum + (r.route?.outputAmount || 0),
+    0,
+  );
+  const totalFees = routes.reduce(
+    (sum, r) => sum + (r.route?.totalNetworkFeeMicroAlgos || 0),
+    0,
+  );
+  // Each leg carries its own hops; spreading only routes[0]?.route would silently drop every
+  // other leg's hops even though inputAmount/outputAmount/txsToSign are (correctly)
+  // summed/concatenated across all legs - merge them so the displayed route accounts for the
+  // full split.
+  const combinedHops: biatecRouter.HopExecution[] = routes.flatMap(
+    (r) => r.route?.hops || [],
+  );
+  const combinedTxsToSign: string[] = routes.flatMap((r) => r.txsToSign || []);
+  const route: biatecRouter.QuoteRoute = {
+    ...routes[0]?.route,
+    hops: combinedHops,
+    inputAmount: totalInputAmount,
+    outputAmount: totalOutputAmount,
+    totalNetworkFeeMicroAlgos: totalFees,
+  };
+  return {
+    route,
+    txsToSign: combinedTxsToSign,
+  };
+}

--- a/src/scripts/aggregators/types.ts
+++ b/src/scripts/aggregators/types.ts
@@ -73,7 +73,7 @@ export type FolksTxnsData = FolksSwapTransactions;
 
 export interface BiatecCombinedRoute {
   // Hops merged across every leg of a split route - see combineRouteResponse
-  // in biatec.ts.
+  // in combineBiatecRoute.ts.
   route: biatecRouter.QuoteRoute;
   txsToSign: string[];
 }


### PR DESCRIPTION
## Problem

When Biatec Router splits a swap across multiple legs (e.g. 40% / 40% / 20% of the amount), the Swap page's route summary displayed only the **first leg's** input as INPUT — e.g. 40 USDC shown for a swap that actually pays 100 USDC. This made Biatec Router quotes look far worse than they really are.

## Root cause

`combineRouteResponse` in `src/scripts/aggregators/biatec.ts` summed `outputAmount` and `totalNetworkFeeMicroAlgos` across all legs and concatenated hops/txsToSign, but spread `routes[0]?.route` for everything else — leaving `inputAmount` as leg 1's value only. `buildBiatecRouteInfo` then rendered that as the route's INPUT.

## Fix (TDD)

- Extracted the pure combination logic into `src/scripts/aggregators/combineBiatecRoute.ts` (type-only imports, so it's testable in plain Node).
- Added a Node-only Playwright unit suite (`pnpm run test:unit`, new `playwright.unit.config.ts` — no browser/server/video) reproducing the 40/40/20 split from the report. The inputAmount assertions failed against the original logic (red), then passed after summing `inputAmount` across legs (green). 5/5 tests pass.
- Signing/execution behavior is unchanged — only the combined quote's `inputAmount` now reflects the full amount paid.

## Verification

- `pnpm run test:unit` — 5 passed
- `pnpm run lint`, `pnpm run check-typescript-errors-vue`, `pnpm run build` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)